### PR TITLE
fix: second try to override fields

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,15 +36,9 @@ function openapiValidator(options: OpenApiValidatorOpts) {
   const oav = new OpenApiValidator(options);
   exports.middleware._oav = oav;
 
-  const overrides = options.specOverrides || [];
-  const apiDoc = overrides.reduce(
-    (acc, override) => set(acc, override.path, override.value),
-    cloneDeep(options.apiSpec),
-  );
-
   return oav.installMiddleware(
     new OpenApiSpecLoader({
-      apiDoc,
+      apiDoc: options.apiSpec,
       validateApiSpec: options.validateApiSpec,
       $refParser: options.$refParser,
     }).load(),


### PR DESCRIPTION
Turned out that we didn't have access to the actual api-spec in the last place we tried to do the override